### PR TITLE
Switch to pyglet

### DIFF
--- a/ThreeDEngine/app.py
+++ b/ThreeDEngine/app.py
@@ -1,0 +1,21 @@
+import pyglet
+from pyglet.gl import *
+
+from ThreeDEngine.options import Options
+from ThreeDEngine.camera import Camera
+
+
+class App(pyglet.window.Window):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        pyglet.clock.schedule_interval(self.schedule_callback, 1/Options.fps)
+        pyglet.app.run()
+        glClearColor(*Options.background_color)
+
+        self.start()
+
+    def schedule_callback(self, dt):
+        self.update(dt)
+        self.clear()
+        glLineWidth(Options.stroke_width)
+        self.render()

--- a/ThreeDEngine/draw.py
+++ b/ThreeDEngine/draw.py
@@ -3,7 +3,7 @@ from ThreeDEngine.options import Options
 from ThreeDEngine.camera import Camera
 from ThreeDEngine.face import Face
 
-def cube(pos: vec3, size: vec3, outline=False):
+def cube(pos: vec3, size: vec3, color, outline=False):
     """
     Draw a cube.
 
@@ -43,7 +43,7 @@ def cube(pos: vec3, size: vec3, outline=False):
     faces.sort(key=lambda face: face.get_center_pos()[1], reverse=True)
 
     for face in faces:
-        face.render(outline)
+        face.render(color, outline)
 
 
 # def pyramid(tip: vec3, height, base, outline=False):

--- a/ThreeDEngine/draw.py
+++ b/ThreeDEngine/draw.py
@@ -3,7 +3,7 @@ from ThreeDEngine.options import Options
 from ThreeDEngine.camera import Camera
 from ThreeDEngine.face import Face
 
-def cube(surface, pos: vec3, size: vec3, outline=False):
+def cube(pos: vec3, size: vec3, outline=False):
     """
     Draw a cube.
 
@@ -43,10 +43,10 @@ def cube(surface, pos: vec3, size: vec3, outline=False):
     faces.sort(key=lambda face: face.get_center_pos()[1], reverse=True)
 
     for face in faces:
-        face.render(surface, outline)
+        face.render(outline)
 
 
-# def pyramid(surface, tip: vec3, height, base, outline=False):
+# def pyramid(tip: vec3, height, base, outline=False):
 #     """
 #     Draw a pyramid
 

--- a/ThreeDEngine/face.py
+++ b/ThreeDEngine/face.py
@@ -1,5 +1,5 @@
 import pyglet
-from pyglet.gl import GL_POLYGON, GL_LINES
+from pyglet.gl import *
 from glm import vec2
 
 from ThreeDEngine.util import *
@@ -38,7 +38,7 @@ class Face:
         offset = vec2(Options.window_size.x / 2, Options.window_size.y / 2)
         projections = []
         for vertex in self.vertices:
-            if vertex.z >= Camera.pos.z:
+            if vertex.z >= Camera.pos.z + Options.render_dist[0] and vertex.z <= Camera.pos.z + Options.render_dist[1]:
                 try:
                     projection = vec2(
                         fov * (vertex.x - Camera.pos.x) / (vertex.z - Camera.pos.z),
@@ -56,20 +56,22 @@ class Face:
         return projections
 
 
-    def render(self, outline=False):
+    def render(self, color, outline):
         projections = self.get_projected_vertices()
         length = len(projections)
+        c = []
 
-        if length > 4:
-            if outline:
-                pyglet.graphics.draw(
-                    length // 2,
-                    GL_LINES,
-                    ('v2f', projections)
-                )
-            else:
-                pyglet.graphics.draw(
-                    length // 2,
-                    GL_POLYGON,
-                    ('v2f', projections)
-                )
+        for i in range(length // 2):
+            c.extend(color)
+        
+        vertex_list = pyglet.graphics.vertex_list(
+            length // 2,
+            ("v2f", projections),
+            ("c3B", c)
+        )
+
+        if outline:
+            glLineWidth(Options.stroke_width)
+            vertex_list.draw(GL_LINE_LOOP)
+        else:
+            vertex_list.draw(GL_POLYGON)

--- a/ThreeDEngine/face.py
+++ b/ThreeDEngine/face.py
@@ -1,9 +1,10 @@
+import pyglet
+from pyglet.gl import GL_POLYGON, GL_LINES
+from glm import vec2
+
 from ThreeDEngine.util import *
 from ThreeDEngine.camera import Camera
 from ThreeDEngine.options import Options
-
-from pygame.draw import polygon
-from glm import vec2
 
 
 class Face:
@@ -49,15 +50,26 @@ class Face:
                         fov * (vertex.y - Camera.pos.y)
                     ) + offset
             
-                projections.append(projection)
+                projections.append(projection.x)
+                projections.append(projection.y)
 
         return projections
 
 
-    def render(self, surface, outline=False):
+    def render(self, outline=False):
         projections = self.get_projected_vertices()
-        if len(projections) > 2:
+        length = len(projections)
+
+        if length > 4:
             if outline:
-                polygon(surface, Options.stroke_color, projections, Options.stroke_width)
+                pyglet.graphics.draw(
+                    length // 2,
+                    GL_LINES,
+                    ('v2f', projections)
+                )
             else:
-                polygon(surface, Options.stroke_color, projections)
+                pyglet.graphics.draw(
+                    length // 2,
+                    GL_POLYGON,
+                    ('v2f', projections)
+                )

--- a/ThreeDEngine/options.py
+++ b/ThreeDEngine/options.py
@@ -2,7 +2,7 @@ from glm import vec2
 
 class Options:
     fps = 60
-    window_size = vec2(800, 600)
+    window_size = vec2(1024, 720)
     background_color = (0, 0, 0)
     stroke_color = (255, 255, 255)
     stroke_width = 1

--- a/ThreeDEngine/options.py
+++ b/ThreeDEngine/options.py
@@ -4,5 +4,5 @@ class Options:
     fps = 60
     window_size = vec2(1024, 720)
     background_color = (0, 0, 0)
-    stroke_color = (255, 255, 255)
     stroke_width = 1
+    render_dist = [10, 500]

--- a/example.py
+++ b/example.py
@@ -1,34 +1,26 @@
 import sys
-import pygame
+import pyglet
 from glm import vec3
 from ThreeDEngine.options import Options
 from ThreeDEngine.camera import Camera
 from ThreeDEngine import draw
 
-win = pygame.display.set_mode([int(x) for x in Options.window_size.to_tuple()])
-pygame.display.set_caption("3D")
-clock = pygame.time.Clock()
 
-x = 500
+class App(pyglet.window.Window):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-while True:
-    clock.tick(Options.fps)
+    def on_draw(self):
+        # Camera.pos.x += 3
 
-    for event in pygame.event.get():
-        if event.type == pygame.QUIT:
-            sys.exit()
+        Options.stroke_width = 1
+        Options.stroke_color = (255, 0, 0)
+        draw.cube(vec3(-150 + -500, 250, 500), vec3(300, 500, 300), True)
 
-    x -= 2
+        Options.stroke_color = (255, 255, 255)
+        draw.cube(vec3(300, -180, 100), vec3(300, 300, 300))
 
-    Camera.pos.x += 60 * clock.get_time() / 1000
 
-    win.fill(Options.background_color)
-
-    Options.stroke_width = 1
-    Options.stroke_color = (255, 0, 0)
-    draw.cube(win, vec3(-150 + -500, 250, 500), vec3(300, 500, 300), True)
-
-    Options.stroke_color = (255, 255, 255)
-    draw.cube(win, vec3(300, -180, 100), vec3(300, 300, 300))
-
-    pygame.display.update()
+if __name__ == "__main__":
+    window = App(*Options.window_size.to_tuple(), "3D iz kewl!")
+    pyglet.app.run()

--- a/example.py
+++ b/example.py
@@ -1,29 +1,18 @@
-import sys
 from random import randint
-
-import pyglet
-from pyglet.gl import *
 from glm import vec3
 
+from ThreeDEngine.app import App
 from ThreeDEngine.options import Options
 from ThreeDEngine.camera import Camera
 from ThreeDEngine import draw
 
 
-class App(pyglet.window.Window):
+class Example(App):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.color = [randint(50, 255) for i in range(3)]
-
-        pyglet.clock.schedule_interval(self.schedule_callback, 1/Options.fps)
-        pyglet.app.run()
-        glClearColor(*Options.background_color)
-
-    def schedule_callback(self, dt):
-        self.update(dt)
-        self.clear()
-        glLineWidth(Options.stroke_width)
-        self.render()
+        # Declare your variables before super().__init__() is called
+        
+        super().__init__(*args, **kwargs)
 
     def update(self, dt):
         Camera.pos.x += 100 * dt
@@ -36,4 +25,4 @@ class App(pyglet.window.Window):
 
 
 if __name__ == "__main__":
-    window = App(*Options.window_size.to_tuple(), "3D iz kewl!")
+    window = Example(*Options.window_size.to_tuple(), "3D iz kewl!")

--- a/example.py
+++ b/example.py
@@ -1,6 +1,10 @@
 import sys
+from random import randint
+
 import pyglet
+from pyglet.gl import *
 from glm import vec3
+
 from ThreeDEngine.options import Options
 from ThreeDEngine.camera import Camera
 from ThreeDEngine import draw
@@ -9,18 +13,27 @@ from ThreeDEngine import draw
 class App(pyglet.window.Window):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.color = [randint(50, 255) for i in range(3)]
 
-    def on_draw(self):
-        # Camera.pos.x += 3
+        pyglet.clock.schedule_interval(self.schedule_callback, 1/Options.fps)
+        pyglet.app.run()
+        glClearColor(*Options.background_color)
 
-        Options.stroke_width = 1
-        Options.stroke_color = (255, 0, 0)
-        draw.cube(vec3(-150 + -500, 250, 500), vec3(300, 500, 300), True)
+    def schedule_callback(self, dt):
+        self.update(dt)
+        self.clear()
+        glLineWidth(Options.stroke_width)
+        self.render()
 
-        Options.stroke_color = (255, 255, 255)
-        draw.cube(vec3(300, -180, 100), vec3(300, 300, 300))
+    def update(self, dt):
+        Camera.pos.x += 100 * dt
+
+    def render(self):
+        Options.stroke_width = 5
+        draw.cube(vec3(-500, 550, 400), vec3(300, 500, 300), self.color, True)
+
+        draw.cube(vec3(400, -380, 150), vec3(300, 300, 300), self.color)
 
 
 if __name__ == "__main__":
     window = App(*Options.window_size.to_tuple(), "3D iz kewl!")
-    pyglet.app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pygame
+pyglet
 pyglm


### PR DESCRIPTION
Now the engine uses Pyglet instead of the Pygame for rendering. This brings better performance. This update also includes OOP and Inheritance so that the user has no interaction with Pyglet at all.